### PR TITLE
Add support for OpenRouter, DeepSeek, Groq, and Ollama providers

### DIFF
--- a/apps/web/app/api/ai/chat/route.ts
+++ b/apps/web/app/api/ai/chat/route.ts
@@ -3,18 +3,30 @@ import { type NextRequest, NextResponse } from "next/server";
 const DEFAULT_SYSTEM =
   "You are a helpful scientific writing assistant specializing in photovoltaic research. Help the user write, edit, and improve their academic documents.";
 
-function chooseProvider(
-  provider: string | undefined,
-  anthropicKey: string,
-  openaiKey: string,
-  perplexityKey: string,
-): string | null {
-  if (provider === "perplexity" && perplexityKey) return "perplexity";
-  if (provider === "openai" && openaiKey) return "openai";
-  if (provider === "anthropic" && anthropicKey) return "anthropic";
-  if (anthropicKey) return "anthropic";
-  if (openaiKey) return "openai";
-  if (perplexityKey) return "perplexity";
+function chooseProvider(provider: string | undefined, keys: Record<string, string>): string | null {
+  const available: Record<string, boolean> = {
+    anthropic: !!keys.anthropic,
+    openai: !!keys.openai,
+    perplexity: !!keys.perplexity,
+    openrouter: !!keys.openrouter,
+    deepseek: !!keys.deepseek,
+    groq: !!keys.groq,
+    ollama: true,
+  };
+
+  if (provider && available[provider]) return provider;
+  // Default priority
+  for (const p of [
+    "anthropic",
+    "openai",
+    "openrouter",
+    "deepseek",
+    "groq",
+    "perplexity",
+    "ollama",
+  ]) {
+    if (available[p] && keys[p]) return p;
+  }
   return null;
 }
 
@@ -110,16 +122,138 @@ async function callPerplexity(
   };
 }
 
+async function callOpenRouter(
+  apiKey: string,
+  messages: ChatMessage[],
+  model: string,
+  systemPrompt: string,
+) {
+  const res = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: model || "anthropic/claude-sonnet-4-20250514",
+      messages: [{ role: "system", content: systemPrompt }, ...messages],
+      max_tokens: 4096,
+    }),
+  });
+  if (!res.ok) {
+    const err = await res.text();
+    return { error: `OpenRouter API error: ${res.status} - ${err}`, status: res.status };
+  }
+  const data = await res.json();
+  return {
+    content: data.choices?.[0]?.message?.content || "No response generated.",
+    provider: "openrouter",
+  };
+}
+
+async function callDeepSeek(
+  apiKey: string,
+  messages: ChatMessage[],
+  model: string,
+  systemPrompt: string,
+) {
+  const res = await fetch("https://api.deepseek.com/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: model || "deepseek-chat",
+      messages: [{ role: "system", content: systemPrompt }, ...messages],
+      max_tokens: 4096,
+    }),
+  });
+  if (!res.ok) {
+    const err = await res.text();
+    return { error: `DeepSeek API error: ${res.status} - ${err}`, status: res.status };
+  }
+  const data = await res.json();
+  return {
+    content: data.choices?.[0]?.message?.content || "No response generated.",
+    provider: "deepseek",
+  };
+}
+
+async function callGroq(
+  apiKey: string,
+  messages: ChatMessage[],
+  model: string,
+  systemPrompt: string,
+) {
+  const res = await fetch("https://api.groq.com/openai/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: model || "llama-3.3-70b-versatile",
+      messages: [{ role: "system", content: systemPrompt }, ...messages],
+      max_tokens: 4096,
+    }),
+  });
+  if (!res.ok) {
+    const err = await res.text();
+    return { error: `Groq API error: ${res.status} - ${err}`, status: res.status };
+  }
+  const data = await res.json();
+  return {
+    content: data.choices?.[0]?.message?.content || "No response generated.",
+    provider: "groq",
+  };
+}
+
+async function callOllama(
+  baseUrl: string,
+  messages: ChatMessage[],
+  model: string,
+  systemPrompt: string,
+) {
+  const url = baseUrl || "http://localhost:11434";
+  const res = await fetch(`${url}/api/chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: model || "llama3",
+      messages: [{ role: "system", content: systemPrompt }, ...messages],
+      stream: false,
+    }),
+  });
+  if (!res.ok) {
+    const err = await res.text();
+    return { error: `Ollama error: ${res.status} - ${err}`, status: res.status };
+  }
+  const data = await res.json();
+  return {
+    content: data.message?.content || "No response generated.",
+    provider: "ollama",
+  };
+}
+
 export async function POST(req: NextRequest) {
   try {
     const { messages, model, systemPrompt, provider } = await req.json();
 
-    const anthropicKey = req.headers.get("x-anthropic-key") || process.env.ANTHROPIC_API_KEY || "";
-    const openaiKey = req.headers.get("x-openai-key") || process.env.OPENAI_API_KEY || "";
-    const perplexityKey =
-      req.headers.get("x-perplexity-key") || process.env.PERPLEXITY_API_KEY || "";
+    const providerKeys: Record<string, string> = {
+      anthropic: req.headers.get("x-anthropic-key") || process.env.ANTHROPIC_API_KEY || "",
+      openai: req.headers.get("x-openai-key") || process.env.OPENAI_API_KEY || "",
+      perplexity: req.headers.get("x-perplexity-key") || process.env.PERPLEXITY_API_KEY || "",
+      openrouter: req.headers.get("x-openrouter-key") || process.env.OPENROUTER_API_KEY || "",
+      deepseek: req.headers.get("x-deepseek-key") || process.env.DEEPSEEK_API_KEY || "",
+      groq: req.headers.get("x-groq-key") || process.env.GROQ_API_KEY || "",
+    };
+    const ollamaBaseUrl =
+      req.headers.get("x-ollama-base-url") ||
+      process.env.OLLAMA_BASE_URL ||
+      "http://localhost:11434";
 
-    const chosen = chooseProvider(provider, anthropicKey, openaiKey, perplexityKey);
+    const chosen = chooseProvider(provider, providerKeys);
     if (!chosen) {
       return NextResponse.json(
         { error: "No API key configured. Please add your API key in Settings." },
@@ -128,10 +262,15 @@ export async function POST(req: NextRequest) {
     }
 
     const system = systemPrompt || DEFAULT_SYSTEM;
+
     const handlers: Record<string, () => Promise<Record<string, unknown>>> = {
-      anthropic: () => callAnthropic(anthropicKey, messages, model, system),
-      openai: () => callOpenAI(openaiKey, messages, model, system),
-      perplexity: () => callPerplexity(perplexityKey, messages, model, system),
+      anthropic: () => callAnthropic(providerKeys.anthropic, messages, model, system),
+      openai: () => callOpenAI(providerKeys.openai, messages, model, system),
+      perplexity: () => callPerplexity(providerKeys.perplexity, messages, model, system),
+      openrouter: () => callOpenRouter(providerKeys.openrouter, messages, model, system),
+      deepseek: () => callDeepSeek(providerKeys.deepseek, messages, model, system),
+      groq: () => callGroq(providerKeys.groq, messages, model, system),
+      ollama: () => callOllama(ollamaBaseUrl, messages, model, system),
     };
 
     const result = await handlers[chosen]();

--- a/apps/web/app/api/providers/test/route.ts
+++ b/apps/web/app/api/providers/test/route.ts
@@ -7,6 +7,10 @@ interface TestKeys {
   pineconeKey: string;
   pineconeEnv: string;
   pineconeIndex: string;
+  openrouterKey: string;
+  deepseekKey: string;
+  groqKey: string;
+  ollamaBaseUrl: string;
 }
 
 function getKey(userKey: string, envVar: string): string {
@@ -17,6 +21,7 @@ async function testAnthropic(keys: TestKeys) {
   const apiKey = getKey(keys.anthropicKey, "ANTHROPIC_API_KEY");
   if (!apiKey) return { connected: false, error: "No API key provided" };
 
+  // Use the cheaper claude-3-haiku model for testing to avoid credit issues
   const res = await fetch("https://api.anthropic.com/v1/messages", {
     method: "POST",
     headers: {
@@ -25,14 +30,19 @@ async function testAnthropic(keys: TestKeys) {
       "anthropic-version": "2023-06-01",
     },
     body: JSON.stringify({
-      model: "claude-3-5-haiku-20241022",
-      max_tokens: 10,
-      messages: [{ role: "user", content: "Say ok" }],
+      model: "claude-3-haiku-20240307",
+      max_tokens: 1,
+      messages: [{ role: "user", content: "Hi" }],
     }),
   });
 
   if (res.ok) return { connected: true };
+
   const err = await res.text();
+  // A 400 with "credit" or "billing" in the error still means auth worked
+  if (res.status === 400 && /credit|billing|balance/i.test(err)) {
+    return { connected: true, error: "Connected but account may have low credits" };
+  }
   return { connected: false, error: `HTTP ${res.status}: ${err.slice(0, 200)}` };
 }
 
@@ -53,22 +63,34 @@ async function testPerplexity(keys: TestKeys) {
   const apiKey = getKey(keys.perplexityKey, "PERPLEXITY_API_KEY");
   if (!apiKey) return { connected: false, error: "No API key provided" };
 
-  const res = await fetch("https://api.perplexity.ai/chat/completions", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify({
-      model: "sonar",
-      messages: [{ role: "user", content: "Say ok" }],
-      max_tokens: 10,
-    }),
-  });
+  try {
+    const res = await fetch("https://api.perplexity.ai/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "sonar",
+        messages: [{ role: "user", content: "Hi" }],
+        max_tokens: 1,
+      }),
+    });
 
-  if (res.ok) return { connected: true };
-  const err = await res.text();
-  return { connected: false, error: `HTTP ${res.status}: ${err.slice(0, 200)}` };
+    if (res.ok) return { connected: true };
+    const err = await res.text();
+    if (res.status === 401) {
+      return {
+        connected: false,
+        error:
+          "Invalid API key (HTTP 401). Check your Perplexity key at https://www.perplexity.ai/settings/api",
+      };
+    }
+    return { connected: false, error: `HTTP ${res.status}: ${err.slice(0, 200)}` };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "Connection failed";
+    return { connected: false, error: msg };
+  }
 }
 
 async function testPinecone(keys: TestKeys) {
@@ -87,12 +109,71 @@ async function testPinecone(keys: TestKeys) {
   return { connected: false, error: `HTTP ${res.status}: ${err.slice(0, 200)}` };
 }
 
+async function testOpenRouter(keys: TestKeys) {
+  const apiKey = getKey(keys.openrouterKey, "OPENROUTER_API_KEY");
+  if (!apiKey) return { connected: false, error: "No API key provided" };
+
+  const res = await fetch("https://openrouter.ai/api/v1/models", {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+
+  if (res.ok) return { connected: true };
+  const err = await res.text();
+  return { connected: false, error: `HTTP ${res.status}: ${err.slice(0, 200)}` };
+}
+
+async function testDeepSeek(keys: TestKeys) {
+  const apiKey = getKey(keys.deepseekKey, "DEEPSEEK_API_KEY");
+  if (!apiKey) return { connected: false, error: "No API key provided" };
+
+  const res = await fetch("https://api.deepseek.com/models", {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+
+  if (res.ok) return { connected: true };
+  const err = await res.text();
+  return { connected: false, error: `HTTP ${res.status}: ${err.slice(0, 200)}` };
+}
+
+async function testGroq(keys: TestKeys) {
+  const apiKey = getKey(keys.groqKey, "GROQ_API_KEY");
+  if (!apiKey) return { connected: false, error: "No API key provided" };
+
+  const res = await fetch("https://api.groq.com/openai/v1/models", {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+
+  if (res.ok) return { connected: true };
+  const err = await res.text();
+  return { connected: false, error: `HTTP ${res.status}: ${err.slice(0, 200)}` };
+}
+
+async function testOllama(keys: TestKeys) {
+  const baseUrl = keys.ollamaBaseUrl || "http://localhost:11434";
+
+  try {
+    const res = await fetch(`${baseUrl}/api/tags`);
+    if (res.ok) return { connected: true };
+    const err = await res.text();
+    return { connected: false, error: `HTTP ${res.status}: ${err.slice(0, 200)}` };
+  } catch {
+    return {
+      connected: false,
+      error: `Cannot connect to Ollama at ${baseUrl}. Is Ollama running?`,
+    };
+  }
+}
+
 const testers: Record<string, (keys: TestKeys) => Promise<{ connected: boolean; error?: string }>> =
   {
     anthropic: testAnthropic,
     openai: testOpenAI,
     perplexity: testPerplexity,
     pinecone: testPinecone,
+    openrouter: testOpenRouter,
+    deepseek: testDeepSeek,
+    groq: testGroq,
+    ollama: testOllama,
   };
 
 export async function POST(req: NextRequest) {

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -11,7 +11,16 @@ import {
 } from "@/lib/providers";
 import { useCallback, useEffect, useState } from "react";
 
-const PROVIDERS: ProviderName[] = ["anthropic", "openai", "perplexity", "pinecone"];
+const PROVIDERS: ProviderName[] = [
+  "anthropic",
+  "openai",
+  "perplexity",
+  "openrouter",
+  "deepseek",
+  "groq",
+  "ollama",
+  "pinecone",
+];
 
 function StatusBadge({ status }: { status: ProviderStatus | undefined }) {
   if (!status) {
@@ -50,6 +59,14 @@ export default function SettingsPage() {
     pineconeKey: "",
     pineconeEnv: "",
     pineconeIndex: "",
+    openrouterKey: "",
+    openrouterModel: "anthropic/claude-sonnet-4-20250514",
+    deepseekKey: "",
+    deepseekModel: "deepseek-chat",
+    groqKey: "",
+    groqModel: "llama-3.3-70b-versatile",
+    ollamaModel: "llama3",
+    ollamaBaseUrl: "http://localhost:11434",
   });
   const [statuses, setStatuses] = useState<Record<string, ProviderStatus>>({});
   const [testing, setTesting] = useState<Record<string, boolean>>({});
@@ -112,23 +129,6 @@ export default function SettingsPage() {
     [keys],
   );
 
-  const testAll = useCallback(async () => {
-    setTestingAll(true);
-    const providers = PROVIDERS.filter((p) => {
-      if (p === "anthropic") return !!keys.anthropicKey;
-      if (p === "openai") return !!keys.openaiKey;
-      if (p === "perplexity") return !!keys.perplexityKey;
-      if (p === "pinecone") return !!keys.pineconeKey;
-      return false;
-    });
-    await Promise.all(providers.map((p) => testProvider(p)));
-    setTestingAll(false);
-  }, [keys, testProvider]);
-
-  const toggleShowKey = (provider: string) => {
-    setShowKeys((prev) => ({ ...prev, [provider]: !prev[provider] }));
-  };
-
   const getKeyValue = (provider: ProviderName): string => {
     switch (provider) {
       case "anthropic":
@@ -139,7 +139,38 @@ export default function SettingsPage() {
         return keys.perplexityKey;
       case "pinecone":
         return keys.pineconeKey;
+      case "openrouter":
+        return keys.openrouterKey;
+      case "deepseek":
+        return keys.deepseekKey;
+      case "groq":
+        return keys.groqKey;
+      case "ollama":
+        return "";
     }
+  };
+
+  const testAll = useCallback(async () => {
+    setTestingAll(true);
+    const keyMap: Record<string, string> = {
+      anthropic: keys.anthropicKey,
+      openai: keys.openaiKey,
+      perplexity: keys.perplexityKey,
+      pinecone: keys.pineconeKey,
+      openrouter: keys.openrouterKey,
+      deepseek: keys.deepseekKey,
+      groq: keys.groqKey,
+    };
+    const providers = PROVIDERS.filter((p) => {
+      if (p === "ollama") return true;
+      return !!keyMap[p];
+    });
+    await Promise.all(providers.map((p) => testProvider(p)));
+    setTestingAll(false);
+  }, [keys, testProvider]);
+
+  const toggleShowKey = (provider: string) => {
+    setShowKeys((prev) => ({ ...prev, [provider]: !prev[provider] }));
   };
 
   const setKeyValue = (provider: ProviderName, value: string) => {
@@ -148,6 +179,10 @@ export default function SettingsPage() {
       openai: "openaiKey",
       perplexity: "perplexityKey",
       pinecone: "pineconeKey",
+      openrouter: "openrouterKey",
+      deepseek: "deepseekKey",
+      groq: "groqKey",
+      ollama: "ollamaBaseUrl",
     };
     updateKey(fieldMap[provider], value);
   };
@@ -160,6 +195,14 @@ export default function SettingsPage() {
         return keys.openaiModel;
       case "perplexity":
         return keys.perplexityModel;
+      case "openrouter":
+        return keys.openrouterModel;
+      case "deepseek":
+        return keys.deepseekModel;
+      case "groq":
+        return keys.groqModel;
+      case "ollama":
+        return keys.ollamaModel;
       default:
         return "";
     }
@@ -170,12 +213,21 @@ export default function SettingsPage() {
       anthropic: "anthropicModel",
       openai: "openaiModel",
       perplexity: "perplexityModel",
+      openrouter: "openrouterModel",
+      deepseek: "deepseekModel",
+      groq: "groqModel",
+      ollama: "ollamaModel",
     };
     const field = fieldMap[provider];
     if (field) updateKey(field, value);
   };
 
-  const connectedCount = PROVIDERS.filter((p) => getKeyValue(p)).length;
+  const hasProviderConfigured = (p: ProviderName): boolean => {
+    if (p === "ollama") return true;
+    return !!getKeyValue(p);
+  };
+
+  const connectedCount = PROVIDERS.filter((p) => hasProviderConfigured(p)).length;
   const lastTestedTime = Object.values(statuses).reduce((latest, s) => {
     if (s.lastTested && s.lastTested > latest) return s.lastTested;
     return latest;
@@ -198,7 +250,7 @@ export default function SettingsPage() {
             <div>
               <h2 className="text-lg font-semibold text-white">Connection Status</h2>
               <p className="text-xs text-gray-500 mt-0.5">
-                {connectedCount}/4 providers configured
+                {connectedCount}/{PROVIDERS.length} providers configured
                 {lastTestedTime > 0 && (
                   <> &middot; Last tested {new Date(lastTestedTime).toLocaleTimeString()}</>
                 )}
@@ -207,7 +259,7 @@ export default function SettingsPage() {
             <button
               type="button"
               onClick={testAll}
-              disabled={testingAll || connectedCount === 0}
+              disabled={testingAll}
               className="px-4 py-2 bg-amber-500/20 text-amber-400 rounded-lg text-sm font-medium hover:bg-amber-500/30 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
             >
               {testingAll ? "Testing..." : "Test All Connections"}
@@ -217,7 +269,7 @@ export default function SettingsPage() {
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
             {PROVIDERS.map((provider) => {
               const info = PROVIDER_INFO[provider];
-              const hasKey = !!getKeyValue(provider);
+              const hasKey = hasProviderConfigured(provider);
               const status = statuses[provider];
               return (
                 <div
@@ -256,9 +308,10 @@ export default function SettingsPage() {
           {PROVIDERS.map((provider) => {
             const info = PROVIDER_INFO[provider];
             const models = PROVIDER_MODELS[provider];
-            const hasKey = !!getKeyValue(provider);
+            const hasKey = hasProviderConfigured(provider);
             const status = statuses[provider];
             const isTesting = testing[provider];
+            const needsApiKey = provider !== "ollama";
 
             return (
               <div
@@ -279,42 +332,74 @@ export default function SettingsPage() {
 
                 {/* Card body */}
                 <div className="px-6 py-4 space-y-4">
-                  {/* API Key */}
-                  <div>
-                    <label
-                      className="block text-xs text-gray-400 mb-1.5 font-medium"
-                      htmlFor={`key-${provider}`}
-                    >
-                      API Key
-                    </label>
-                    <div className="flex gap-2">
-                      <div className="flex-1 relative">
+                  {/* API Key (not for Ollama) */}
+                  {needsApiKey && (
+                    <div>
+                      <label
+                        className="block text-xs text-gray-400 mb-1.5 font-medium"
+                        htmlFor={`key-${provider}`}
+                      >
+                        API Key
+                      </label>
+                      <div className="flex gap-2">
+                        <div className="flex-1 relative">
+                          <input
+                            id={`key-${provider}`}
+                            type={showKeys[provider] ? "text" : "password"}
+                            value={getKeyValue(provider)}
+                            onChange={(e) => setKeyValue(provider, e.target.value)}
+                            placeholder={info.placeholder}
+                            className="w-full bg-gray-800/60 border border-gray-700/40 rounded-lg px-3 py-2 text-sm text-gray-200 placeholder-gray-600 focus:outline-none focus:border-amber-500/40 pr-10 font-mono"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => toggleShowKey(provider)}
+                            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-300 text-xs"
+                          >
+                            {showKeys[provider] ? "Hide" : "Show"}
+                          </button>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => testProvider(provider)}
+                          disabled={!hasKey || isTesting}
+                          className="px-4 py-2 bg-gray-800 text-gray-300 rounded-lg text-sm font-medium hover:bg-gray-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap border border-gray-700/40"
+                        >
+                          {isTesting ? "Testing..." : "Test"}
+                        </button>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Ollama base URL + test button */}
+                  {provider === "ollama" && (
+                    <div>
+                      <label
+                        className="block text-xs text-gray-400 mb-1.5 font-medium"
+                        htmlFor="ollama-base-url"
+                      >
+                        Base URL
+                      </label>
+                      <div className="flex gap-2">
                         <input
-                          id={`key-${provider}`}
-                          type={showKeys[provider] ? "text" : "password"}
-                          value={getKeyValue(provider)}
-                          onChange={(e) => setKeyValue(provider, e.target.value)}
-                          placeholder={info.placeholder}
-                          className="w-full bg-gray-800/60 border border-gray-700/40 rounded-lg px-3 py-2 text-sm text-gray-200 placeholder-gray-600 focus:outline-none focus:border-amber-500/40 pr-10 font-mono"
+                          id="ollama-base-url"
+                          type="text"
+                          value={keys.ollamaBaseUrl}
+                          onChange={(e) => updateKey("ollamaBaseUrl", e.target.value)}
+                          placeholder="http://localhost:11434"
+                          className="flex-1 bg-gray-800/60 border border-gray-700/40 rounded-lg px-3 py-2 text-sm text-gray-200 placeholder-gray-600 focus:outline-none focus:border-amber-500/40 font-mono"
                         />
                         <button
                           type="button"
-                          onClick={() => toggleShowKey(provider)}
-                          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-300 text-xs"
+                          onClick={() => testProvider(provider)}
+                          disabled={isTesting}
+                          className="px-4 py-2 bg-gray-800 text-gray-300 rounded-lg text-sm font-medium hover:bg-gray-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap border border-gray-700/40"
                         >
-                          {showKeys[provider] ? "Hide" : "Show"}
+                          {isTesting ? "Testing..." : "Test"}
                         </button>
                       </div>
-                      <button
-                        type="button"
-                        onClick={() => testProvider(provider)}
-                        disabled={!hasKey || isTesting}
-                        className="px-4 py-2 bg-gray-800 text-gray-300 rounded-lg text-sm font-medium hover:bg-gray-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap border border-gray-700/40"
-                      >
-                        {isTesting ? "Testing..." : "Test"}
-                      </button>
                     </div>
-                  </div>
+                  )}
 
                   {/* Model selector (not for Pinecone) */}
                   {models.length > 0 && (
@@ -407,6 +492,10 @@ export default function SettingsPage() {
                 provider: "Pinecone + OpenAI Embeddings",
                 icon: "🌲",
               },
+              { task: "Multi-model Access", provider: "OpenRouter (200+ models)", icon: "🔀" },
+              { task: "Fast Inference", provider: "Groq (open-source models)", icon: "⚡" },
+              { task: "Cost-effective Chat", provider: "DeepSeek", icon: "🌊" },
+              { task: "Local / Offline", provider: "Ollama (no API key)", icon: "🏠" },
             ].map((r) => (
               <div
                 key={r.task}
@@ -433,6 +522,10 @@ export default function SettingsPage() {
             <p>ANTHROPIC_API_KEY=sk-ant-...</p>
             <p>OPENAI_API_KEY=sk-...</p>
             <p>PERPLEXITY_API_KEY=pplx-...</p>
+            <p>OPENROUTER_API_KEY=sk-or-v1-...</p>
+            <p>DEEPSEEK_API_KEY=sk-...</p>
+            <p>GROQ_API_KEY=gsk_...</p>
+            <p>OLLAMA_BASE_URL=http://localhost:11434</p>
             <p>PINECONE_API_KEY=pc-...</p>
             <p>PINECONE_ENVIRONMENT=us-east-1-aws</p>
             <p>PINECONE_INDEX=suryaprajna-index</p>

--- a/apps/web/lib/providers.ts
+++ b/apps/web/lib/providers.ts
@@ -1,7 +1,15 @@
 // SuryaPrajna — lib/providers.ts
 // Provider router, key storage, and connection management.
 
-export type ProviderName = "anthropic" | "openai" | "perplexity" | "pinecone";
+export type ProviderName =
+  | "anthropic"
+  | "openai"
+  | "perplexity"
+  | "pinecone"
+  | "openrouter"
+  | "deepseek"
+  | "groq"
+  | "ollama";
 
 export type TaskType = "chat" | "research" | "writing" | "embedding" | "rag";
 
@@ -11,6 +19,8 @@ export interface ProviderConfig {
   // Pinecone-specific
   environment?: string;
   indexName?: string;
+  // Ollama-specific
+  baseUrl?: string;
 }
 
 export interface ProviderStatus {
@@ -30,6 +40,14 @@ export interface AllProviderKeys {
   pineconeKey: string;
   pineconeEnv: string;
   pineconeIndex: string;
+  openrouterKey: string;
+  openrouterModel: string;
+  deepseekKey: string;
+  deepseekModel: string;
+  groqKey: string;
+  groqModel: string;
+  ollamaModel: string;
+  ollamaBaseUrl: string;
 }
 
 const STORAGE_KEY = "suryaprajna_provider_keys";
@@ -73,6 +91,14 @@ const DEFAULT_KEYS: AllProviderKeys = {
   pineconeKey: "",
   pineconeEnv: "",
   pineconeIndex: "",
+  openrouterKey: "",
+  openrouterModel: "anthropic/claude-sonnet-4-20250514",
+  deepseekKey: "",
+  deepseekModel: "deepseek-chat",
+  groqKey: "",
+  groqModel: "llama-3.3-70b-versatile",
+  ollamaModel: "llama3",
+  ollamaBaseUrl: "http://localhost:11434",
 };
 
 // Sensitive fields that should be obfuscated
@@ -81,6 +107,9 @@ const SENSITIVE_FIELDS: (keyof AllProviderKeys)[] = [
   "openaiKey",
   "perplexityKey",
   "pineconeKey",
+  "openrouterKey",
+  "deepseekKey",
+  "groqKey",
 ];
 
 export function saveProviderKeys(keys: AllProviderKeys): void {
@@ -124,14 +153,18 @@ export function getProviderHeaders(keys: AllProviderKeys): Record<string, string
     "x-pinecone-key": keys.pineconeKey,
     "x-pinecone-env": keys.pineconeEnv,
     "x-pinecone-index": keys.pineconeIndex,
+    "x-openrouter-key": keys.openrouterKey,
+    "x-deepseek-key": keys.deepseekKey,
+    "x-groq-key": keys.groqKey,
+    "x-ollama-base-url": keys.ollamaBaseUrl || "http://localhost:11434",
   };
 }
 
 // Priority order for each task type
 const TASK_PRIORITY: Record<TaskType, ProviderName[]> = {
-  research: ["perplexity", "anthropic", "openai"],
-  writing: ["anthropic", "openai", "perplexity"],
-  chat: ["anthropic", "openai", "perplexity"],
+  research: ["perplexity", "anthropic", "openai", "openrouter", "deepseek", "groq", "ollama"],
+  writing: ["anthropic", "openai", "openrouter", "deepseek", "groq", "perplexity", "ollama"],
+  chat: ["anthropic", "openai", "openrouter", "deepseek", "groq", "perplexity", "ollama"],
   embedding: ["openai"],
   rag: ["pinecone"],
 };
@@ -148,7 +181,7 @@ export function routeProvider(
   // If user explicitly chose a provider and has a key for it, use it
   if (preferredProvider) {
     const key = getKeyForProvider(preferredProvider, keys);
-    if (key) {
+    if (key || preferredProvider === "ollama") {
       return {
         provider: preferredProvider,
         model: getModelForProvider(preferredProvider, keys),
@@ -168,7 +201,7 @@ export function routeProvider(
   const priorities = TASK_PRIORITY[task];
   for (const provider of priorities) {
     const key = getKeyForProvider(provider, keys);
-    if (key) {
+    if (key || provider === "ollama") {
       const model =
         task === "embedding" ? "text-embedding-3-small" : getModelForProvider(provider, keys);
       return { provider, model };
@@ -188,6 +221,14 @@ function getKeyForProvider(provider: ProviderName, keys: AllProviderKeys): strin
       return keys.perplexityKey;
     case "pinecone":
       return keys.pineconeKey;
+    case "openrouter":
+      return keys.openrouterKey;
+    case "deepseek":
+      return keys.deepseekKey;
+    case "groq":
+      return keys.groqKey;
+    case "ollama":
+      return "";
   }
 }
 
@@ -201,6 +242,14 @@ function getModelForProvider(provider: ProviderName, keys: AllProviderKeys): str
       return keys.perplexityModel;
     case "pinecone":
       return "";
+    case "openrouter":
+      return keys.openrouterModel;
+    case "deepseek":
+      return keys.deepseekModel;
+    case "groq":
+      return keys.groqModel;
+    case "ollama":
+      return keys.ollamaModel;
   }
 }
 
@@ -224,6 +273,27 @@ export const PROVIDER_MODELS: Record<ProviderName, { value: string; label: strin
     { value: "sonar-reasoning", label: "Sonar Reasoning" },
   ],
   pinecone: [],
+  openrouter: [
+    { value: "anthropic/claude-sonnet-4-20250514", label: "Claude Sonnet 4" },
+    { value: "openai/gpt-4o", label: "GPT-4o" },
+    { value: "google/gemini-2.5-pro-preview", label: "Gemini 2.5 Pro" },
+    { value: "meta-llama/llama-3.3-70b-instruct", label: "Llama 3.3 70B" },
+  ],
+  deepseek: [
+    { value: "deepseek-chat", label: "DeepSeek Chat (V3)" },
+    { value: "deepseek-reasoner", label: "DeepSeek Reasoner (R1)" },
+  ],
+  groq: [
+    { value: "llama-3.3-70b-versatile", label: "Llama 3.3 70B" },
+    { value: "llama-3.1-8b-instant", label: "Llama 3.1 8B" },
+    { value: "mixtral-8x7b-32768", label: "Mixtral 8x7B" },
+  ],
+  ollama: [
+    { value: "llama3", label: "Llama 3" },
+    { value: "llama3.1", label: "Llama 3.1" },
+    { value: "mistral", label: "Mistral" },
+    { value: "codellama", label: "Code Llama" },
+  ],
 };
 
 export const PROVIDER_INFO: Record<
@@ -253,5 +323,29 @@ export const PROVIDER_INFO: Record<
     icon: "🌲",
     description: "RAG knowledge base, semantic search over uploaded papers",
     placeholder: "pc-...",
+  },
+  openrouter: {
+    label: "OpenRouter",
+    icon: "🔀",
+    description: "Unified API gateway to 200+ models from multiple providers",
+    placeholder: "sk-or-v1-...",
+  },
+  deepseek: {
+    label: "DeepSeek",
+    icon: "🌊",
+    description: "Cost-effective reasoning and chat models",
+    placeholder: "sk-...",
+  },
+  groq: {
+    label: "Groq",
+    icon: "⚡",
+    description: "Ultra-fast inference for open-source models",
+    placeholder: "gsk_...",
+  },
+  ollama: {
+    label: "Ollama (Local)",
+    icon: "🏠",
+    description: "Run open-source models locally, no API key needed",
+    placeholder: "",
   },
 };


### PR DESCRIPTION
## Summary
Extends the AI provider system to support four additional LLM providers: OpenRouter (multi-model gateway), DeepSeek (cost-effective reasoning), Groq (fast inference), and Ollama (local/offline models). This gives users more flexibility in choosing their preferred AI backend.

## Key Changes

**Provider Infrastructure**
- Added `openrouter`, `deepseek`, `groq`, and `ollama` to the `ProviderName` type
- Extended `AllProviderKeys` interface with configuration for each new provider (API keys, models, base URLs)
- Updated `PROVIDER_INFO` and `PROVIDER_MODELS` constants with metadata and available models for each provider

**Settings Page (`apps/web/app/settings/page.tsx`)**
- Expanded provider list from 4 to 8 providers
- Added model configuration fields for each new provider with sensible defaults
- Implemented special handling for Ollama (no API key required, uses base URL instead)
- Updated "Test All Connections" logic to handle providers without API keys
- Refactored `getKeyValue()` and `setKeyValue()` to support new providers
- Updated connection status display to show dynamic provider count
- Added UI sections for Ollama base URL configuration
- Updated environment variable examples in documentation

**Chat API (`apps/web/app/api/ai/chat/route.ts`)**
- Refactored `chooseProvider()` to use a flexible key map instead of individual parameters
- Implemented `callOpenRouter()`, `callDeepSeek()`, `callGroq()`, and `callOllama()` functions
- Each function follows the same pattern: fetch from provider API, handle errors, return standardized response
- Updated request handler to pass all provider keys and route to appropriate handler

**Provider Testing (`apps/web/app/providers/test/route.ts`)**
- Added test functions for each new provider using lightweight API calls
- Implemented error handling for Ollama connection failures with helpful messages
- Added special handling for Anthropic billing/credit errors (still counts as connected)
- Improved Perplexity error messages for invalid API keys

**Provider Routing (`apps/web/lib/providers.ts`)**
- Updated task priority lists to include new providers
- Modified `routeProvider()` to allow Ollama selection without requiring an API key
- Extended `getKeyForProvider()` and `getModelForProvider()` helper functions
- Added new providers to sensitive fields list for secure storage

## Notable Implementation Details

- **Ollama special case**: Ollama doesn't require an API key and can be tested/used without credentials, enabling local-only workflows
- **Model defaults**: Each provider has sensible default models (Claude Sonnet 4 for OpenRouter, DeepSeek Chat for DeepSeek, etc.)
- **Error handling**: Improved error messages for authentication failures and connection issues
- **Backward compatibility**: Existing provider configurations remain unchanged; new providers are additive

https://claude.ai/code/session_01PBpNCwjPsBvBAGGHKmKTPW