### PR TITLE
fix: align pnpm version in CI to match packageManager (9.15.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 9.15.4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 9.15.4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 9.15.4
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## Fix CI Pipeline - pnpm Version Mismatch

All 3 CI jobs (Lint, Type Check, Test) were failing because `pnpm/action-setup@v4` had `version: 9` which conflicts with `packageManager: pnpm@9.15.4` in package.json.

### Changes
- Updated `version: 9` to `version: 9.15.4` in all 3 CI jobs (lint, typecheck, test)
- Aligns CI workflow with the exact pnpm version specified in package.json