### PR TITLE
feat: Publisher Templates Gallery + AI Content Generator + Editor Fixes (Closes #36)

### DIFF
--- a/apps/web/components/editor/TemplatesGallery.tsx
+++ b/apps/web/components/editor/TemplatesGallery.tsx
@@ -8,6 +8,8 @@ interface Template {
   description: string;
   icon: string;
   category: string;
+  publisher?: string;
+  badge?: string;
 }
 
 interface TemplatesGalleryProps {
@@ -17,6 +19,80 @@ interface TemplatesGalleryProps {
 }
 
 const TEMPLATES: Template[] = [
+  // === PV JOURNAL PUBLISHERS ===
+  {
+    id: "wiley-pip",
+    name: "Progress in Photovoltaics (Wiley)",
+    description: "Wiley journal format for Progress in Photovoltaics: Research and Applications",
+    icon: "📗",
+    category: "PV Journals",
+    publisher: "Wiley",
+    badge: "IF: 7.9",
+  },
+  {
+    id: "wiley-aem",
+    name: "Advanced Energy Materials (Wiley)",
+    description: "High-impact Wiley journal for advanced energy research including PV",
+    icon: "⚡",
+    category: "PV Journals",
+    publisher: "Wiley",
+    badge: "IF: 27.8",
+  },
+  {
+    id: "nature-energy",
+    name: "Nature Energy",
+    description: "Nature portfolio journal for energy research with strict formatting",
+    icon: "🌍",
+    category: "PV Journals",
+    publisher: "Nature",
+    badge: "IF: 56.7",
+  },
+  {
+    id: "science-aaas",
+    name: "Science (AAAS)",
+    description: "AAAS Science journal format for breakthrough PV research",
+    icon: "🔬",
+    category: "PV Journals",
+    publisher: "AAAS",
+    badge: "IF: 56.9",
+  },
+  {
+    id: "acs-energy-letters",
+    name: "ACS Energy Letters",
+    description: "American Chemical Society letter format for rapid PV communications",
+    icon: "🧪",
+    category: "PV Journals",
+    publisher: "ACS",
+    badge: "IF: 19.3",
+  },
+  {
+    id: "solar-energy-elsevier",
+    name: "Solar Energy (Elsevier)",
+    description: "Elsevier Solar Energy journal with highlights and graphical abstract",
+    icon: "☀️",
+    category: "PV Journals",
+    publisher: "Elsevier",
+    badge: "IF: 6.7",
+  },
+  {
+    id: "ieee-jpv",
+    name: "IEEE Journal of Photovoltaics",
+    description: "IEEE journal dedicated to photovoltaic device and system research",
+    icon: "📰",
+    category: "PV Journals",
+    publisher: "IEEE",
+    badge: "IF: 2.8",
+  },
+  {
+    id: "joule-cell-press",
+    name: "Joule (Cell Press)",
+    description: "Cell Press journal for sustainable energy research and policy",
+    icon: "🔋",
+    category: "PV Journals",
+    publisher: "Cell Press",
+    badge: "IF: 39.8",
+  },
+  // === GENERAL RESEARCH ===
   {
     id: "pv-research",
     name: "PV Research Paper",
@@ -66,6 +142,7 @@ const TEMPLATES: Template[] = [
     icon: "📚",
     category: "Research",
   },
+  // === REPORTS ===
   {
     id: "technical-report",
     name: "Technical Report",
@@ -73,6 +150,7 @@ const TEMPLATES: Template[] = [
     icon: "📋",
     category: "Reports",
   },
+  // === STANDARDS ===
   {
     id: "iec-test-report",
     name: "IEC Test Report",
@@ -80,6 +158,7 @@ const TEMPLATES: Template[] = [
     icon: "🏗️",
     category: "Standards",
   },
+  // === RELIABILITY ===
   {
     id: "fmea-report",
     name: "FMEA Report",
@@ -87,6 +166,7 @@ const TEMPLATES: Template[] = [
     icon: "⚠️",
     category: "Reliability",
   },
+  // === ENGINEERING ===
   {
     id: "energy-yield",
     name: "Energy Yield Analysis Report",
@@ -101,6 +181,7 @@ const TEMPLATES: Template[] = [
     icon: "📊",
     category: "Engineering",
   },
+  // === ACADEMIC ===
   {
     id: "thesis-chapter",
     name: "Thesis / Dissertation",
@@ -122,6 +203,7 @@ const TEMPLATES: Template[] = [
     icon: "📝",
     category: "Academic",
   },
+  // === LEGAL ===
   {
     id: "patent-draft",
     name: "Patent Draft",
@@ -130,6 +212,16 @@ const TEMPLATES: Template[] = [
     category: "Legal",
   },
 ];
+
+const PUBLISHER_COLORS: Record<string, string> = {
+  Wiley: "bg-blue-500/15 text-blue-400 border-blue-500/30",
+  Nature: "bg-red-500/15 text-red-400 border-red-500/30",
+  AAAS: "bg-yellow-500/15 text-yellow-400 border-yellow-500/30",
+  ACS: "bg-purple-500/15 text-purple-400 border-purple-500/30",
+  Elsevier: "bg-orange-500/15 text-orange-400 border-orange-500/30",
+  IEEE: "bg-cyan-500/15 text-cyan-400 border-cyan-500/30",
+  "Cell Press": "bg-green-500/15 text-green-400 border-green-500/30",
+};
 
 export default function TemplatesGallery({ isOpen, onClose, onSelect }: TemplatesGalleryProps) {
   const [filter, setFilter] = useState<string>("all");
@@ -143,19 +235,20 @@ export default function TemplatesGallery({ isOpen, onClose, onSelect }: Template
     const matchesSearch =
       !searchQuery ||
       t.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      t.description.toLowerCase().includes(searchQuery.toLowerCase());
+      t.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      (t.publisher && t.publisher.toLowerCase().includes(searchQuery.toLowerCase()));
     return matchesCategory && matchesSearch;
   });
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-      <div className="bg-gray-900 border border-gray-700/60 rounded-xl w-full max-w-4xl max-h-[80vh] overflow-hidden shadow-2xl flex flex-col">
+      <div className="bg-gray-900 border border-gray-700/60 rounded-xl w-full max-w-5xl max-h-[85vh] overflow-hidden shadow-2xl flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-800/60 flex-shrink-0">
           <div>
             <h2 className="text-lg font-semibold text-white">Template Gallery</h2>
             <p className="text-xs text-gray-500 mt-0.5">
-              {TEMPLATES.length} templates for academic papers, reports, and technical documents
+              {TEMPLATES.length} templates — PV journals, academic papers, reports & technical documents
             </p>
           </div>
           <button
@@ -163,7 +256,7 @@ export default function TemplatesGallery({ isOpen, onClose, onSelect }: Template
             onClick={onClose}
             className="text-gray-500 hover:text-gray-300 text-xl leading-none"
           >
-            ×
+            &times;
           </button>
         </div>
 
@@ -173,7 +266,7 @@ export default function TemplatesGallery({ isOpen, onClose, onSelect }: Template
             type="text"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="Search templates..."
+            placeholder="Search templates or publishers (Wiley, Nature, IEEE...)"
             className="w-full bg-gray-800/60 border border-gray-700/40 rounded-lg px-3 py-1.5 text-sm text-gray-200 placeholder-gray-600 focus:outline-none focus:border-amber-500/40"
           />
           <div className="flex gap-2 flex-wrap">
@@ -196,7 +289,7 @@ export default function TemplatesGallery({ isOpen, onClose, onSelect }: Template
 
         {/* Templates Grid */}
         <div className="flex-1 overflow-auto p-6">
-          <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
             {filtered.map((t) => (
               <button
                 type="button"
@@ -207,16 +300,30 @@ export default function TemplatesGallery({ isOpen, onClose, onSelect }: Template
                 }}
                 className="text-left p-4 rounded-lg border border-gray-700/40 bg-gray-800/30 hover:bg-gray-800/60 hover:border-amber-500/30 transition-all group"
               >
-                <div className="flex items-center gap-3 mb-2">
+                <div className="flex items-center gap-2 mb-2">
                   <span className="text-2xl">{t.icon}</span>
-                  <div>
-                    <h3 className="text-sm font-medium text-white group-hover:text-amber-300 transition-colors">
+                  <div className="flex-1 min-w-0">
+                    <h3 className="text-sm font-medium text-white group-hover:text-amber-300 transition-colors truncate">
                       {t.name}
                     </h3>
-                    <span className="text-xs text-gray-600">{t.category}</span>
+                    <div className="flex items-center gap-1.5 mt-0.5">
+                      <span className="text-xs text-gray-600">{t.category}</span>
+                      {t.publisher && (
+                        <span
+                          className={`text-[10px] px-1.5 py-0.5 rounded-full border font-medium ${
+                            PUBLISHER_COLORS[t.publisher] || "bg-gray-700/30 text-gray-400 border-gray-600/30"
+                          }`}
+                        >
+                          {t.publisher}
+                        </span>
+                      )}
+                    </div>
                   </div>
                 </div>
-                <p className="text-xs text-gray-400">{t.description}</p>
+                <p className="text-xs text-gray-400 line-clamp-2">{t.description}</p>
+                {t.badge && (
+                  <div className="mt-2 text-[10px] text-amber-500/70 font-mono">{t.badge}</div>
+                )}
               </button>
             ))}
           </div>


### PR DESCRIPTION
## Changes

### 1. Publisher Templates Gallery Enhancement
- Added 8 new PV journal publisher templates: Wiley PiP, Wiley AEM, Nature Energy, Science (AAAS), ACS Energy Letters, Solar Energy (Elsevier), IEEE JPV, Joule (Cell Press)
- Publisher badge with color coding and Impact Factor display
- Enhanced search to include publisher names
- 4-column responsive grid layout
- Total templates: 24 (up from 16)

### 2. AI Content Generator Wiring
- Wire existing AIContentGenerator into editor page
- Add Generate Section, Expand, Abstract Generator, Conclusion Generator actions
- Connected to multi-provider AI system

### 3. Editor Fixes
- Wire EquationOCR keyboard shortcut (Ctrl+Shift+E)
- Add MathPix config in Settings
- Template content for all new publisher templates

Closes #36