### PR TITLE
fix: add missing FONT_FAMILIES const declaration (Closes #40)

### DIFF
--- a/apps/web/components/editor/SettingsPanel.tsx
+++ b/apps/web/components/editor/SettingsPanel.tsx
@@ -53,6 +53,8 @@ const DEFAULT_SETTINGS: EditorSettings = {
 
 export { DEFAULT_SETTINGS };
 
+const FONT_FAMILIES = [
+
 
   { value: "JetBrains Mono", label: "JetBrains Mono" },
   { value: "Fira Code", label: "Fira Code" },


### PR DESCRIPTION
Fixes build failure from PR #39 merge.

## Root Cause
The `const FONT_FAMILIES = [` declaration was accidentally dropped during the PR #39 edit, leaving bare array items as a syntax error.

## Fix
Added back the missing `const FONT_FAMILIES = [` declaration line.

Closes #40