### PR TITLE
fix: move ProofreadPanel inside root div to fix JSX syntax error

### DIFF
--- a/apps/web/app/editor/page.tsx
+++ b/apps/web/app/editor/page.tsx
@@ -1446,7 +1446,6 @@ table{border-collapse:collapse;width:100%}td,th{border:1px solid #000;padding:6p
         onInsertText={insertAtCursor}
         onReplaceSelection={selectedText ? replaceSelection : undefined}
       />
-    </div>
           {showProofreadPanel && (
         <div className="fixed inset-y-0 right-0 z-50 shadow-2xl flex">
           <ProofreadPanel
@@ -1455,5 +1454,6 @@ table{border-collapse:collapse;width:100%}td,th{border:1px solid #000;padding:6p
           />
         </div>
       )}
+          </div>
   );
 }


### PR DESCRIPTION
Fixes Vercel build failure from PR #44 and #45.

The ProofreadPanel JSX block was placed after the root `</div>` closing tag, resulting in `Expected ','` syntax error at line 1447. This moves it inside the root div.