### PR TITLE
fix: add bibtex property to Reference type

### DIFF
--- a/apps/web/components/editor/ReferenceManager.tsx
+++ b/apps/web/components/editor/ReferenceManager.tsx
@@ -14,6 +14,7 @@ export interface Reference {
   volume?: string;
   pages?: string;
   publisher?: string;
+    bibtex?: string;
 }
 
 interface ReferenceManagerProps {


### PR DESCRIPTION
Fix build error: Property 'bibtex' does not exist on type 'Reference'. Added bibtex optional field to Reference interface.