### PR TITLE
fix: replace Set spread with Array.from for downlevelIteration compat

### DIFF
--- a/apps/web/components/editor/ProofreadPanel.tsx
+++ b/apps/web/components/editor/ProofreadPanel.tsx
@@ -111,7 +111,7 @@ export default function ProofreadPanel({ content, onClose }: ProofreadPanelProps
   }) ?? [];
 
   const categories = result
-    ? ([...new Set(result.issues.map(i => i.category))] as IssueCategory[])
+    ? (Array.from(new Set(result.issues.map(i => i.category))) as IssueCategory[])
     : [];
 
   return (


### PR DESCRIPTION
Fixes Vercel build failure caused by `[...new Set()]` spread syntax.

## Error
`ProofreadPanel.tsx:114:12` - Type 'Set' can only be iterated through when using '--downlevelIteration' flag

## Fix
Replaced `[...new Set(...)]` with `Array.from(new Set(...))` which is compatible with ES5 target.