### PR TITLE
fix: enable downlevelIteration in tsconfig for ES5 iterator compat

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
+        "downlevelIteration": true,
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Adds `downlevelIteration: true` to tsconfig.json to fix ALL iterator-related build failures.

This is the root fix - the `target: es5` setting prevents iteration of `Set`, `Map`, `matchAll()` etc. without this flag. Fixes ProofreadPanel.tsx Set spread and proofreadAnalyzer.ts RegExp matchAll issues in one shot.